### PR TITLE
Honour encoding on the result rows if not set.

### DIFF
--- a/lib/postgres-pr/connection.rb
+++ b/lib/postgres-pr/connection.rb
@@ -119,7 +119,7 @@ class Connection
       msg = Message.read(@conn)
       case msg
       when DataRow
-        result.rows << msg.columns
+        result.rows << msg.columns.map{|f| set_encoding(f) }
       when CommandComplete
         result.cmd_tag = msg.cmd_tag
       when ReadyForQuery
@@ -170,6 +170,15 @@ class Connection
       raise PGError, 'unrecognized uri scheme format (must be tcp or unix)'
     end
   end
+
+  def set_encoding(string)
+    if string.encoding == Encoding::ASCII_8BIT && Encoding.default_external
+      string.force_encoding(Encoding.default_external).encode!
+    else
+      string
+    end
+  end
+
 end
 
 end # module PostgresPR


### PR DESCRIPTION
This patch changes the Connection class so that the results returned by a query honour the `Encoding.default_external` and `Encoding.default_internal` settings, just as if the data had been read from a file.

You were kind enough to answer my [question](http://stackoverflow.com/questions/37854812/how-do-i-stop-sequels-postgres-pr-adaptor-from-returning-data-in-the-wrong-enco/37878181#37878181) on StackOverflow and suggested that you were open to a patch.  (If you literally want a patch file and not a pull request, I can of course do that; just let me know where you would like me to send it.)

The question above describes the problem I am trying to solve here; I see data from the database appearing with an encoding of ASCII_8BIt even though the database is UTF_8 and so is my Encoding.default_external.

Note that this change has no effect at all on anything other than the result rows in the query, and only then if the result rows appear to have no encoding (ASCII_8BIT).  This is specifically so that there is no risk of change to other parts of the product, to Sequel, or to people who are not having this problem.

As far as I can tell, this is a complete, working change, ready to be pulled.  You may of course disagree!  I'm absolutely fine with that.  If you would like me to redo in some way, that's fine too.  Just let me know how I can help.
